### PR TITLE
remove forced uppercase displayed hotkeys

### DIFF
--- a/src/cmd-action.ts
+++ b/src/cmd-action.ts
@@ -95,7 +95,6 @@ export class CmdAction extends LitElement {
 				.replace('shift', '⇧')
 				.replace('alt', '⌥')
 				.replace('ctrl', '⌃')
-				.toUpperCase()
 				.split('+');
 			return hotkeys.length > 0 ? html`<span>${repeat(hotkeys, hotkey => html`<kbd part="kbd">${hotkey}</kbd>`)}</span>` : '';
 		}


### PR DESCRIPTION
The hotkeys defined are forced into uppercase to display, this is incorrect. 

A lower case s defined as the hotkey would show in the dialog as a capital S

to get a capital S you would press `SHIFT + s` (s being the key on the keyboard) to get a capital S which is incorrect and doesnt trigger the hotkey.

Hard to see sS but easier to see the problem with `l` verses `L` or `i` verses `I`