### PR TITLE
Prevent hotkeys used when our dialog is open - take 2

### DIFF
--- a/src/cmd-dialog.ts
+++ b/src/cmd-dialog.ts
@@ -127,7 +127,7 @@ export class CmdDialog extends LitElement {
 					&& event.key !== 'ArrowDown'
 					&& event.key !== 'Tab'
 				)));
-		}
+		};
 	}
 
 	override disconnectedCallback() {

--- a/src/cmd-dialog.ts
+++ b/src/cmd-dialog.ts
@@ -121,8 +121,13 @@ export class CmdDialog extends LitElement {
 
 		// Prevent hotkeys used when our dialog is open
 		hotkeys.filter = function (event) {
-			return !document.querySelector('cmd-dialog').dialog.open;
-		};
+			return (!((event.target || event.srcElement).tagName === 'CMD-DIALOG'
+				&& (
+					event.key !== 'ArrowUp'
+					&& event.key !== 'ArrowDown'
+					&& event.key !== 'Tab'
+				)));
+		}
 	}
 
 	override disconnectedCallback() {

--- a/src/cmd-dialog.ts
+++ b/src/cmd-dialog.ts
@@ -121,7 +121,7 @@ export class CmdDialog extends LitElement {
 
 		// Prevent hotkeys used when our dialog is open
 		hotkeys.filter = function (event) {
-			return (!((event.target || event.srcElement).tagName === 'CMD-DIALOG'
+			return (!((event.target ?? event.srcElement).tagName === 'CMD-DIALOG'
 				&& (
 					event.key !== 'ArrowUp'
 					&& event.key !== 'ArrowDown'


### PR DESCRIPTION
Different approach here, using the event data to determine if we are in the dialog and allowing the arrows and tab (shift tab also works as does escape) 